### PR TITLE
Install package when building json

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,6 +1,8 @@
 - project:
     merge-mode: squash-merge
     default-branch: main
+    vars:
+      sphinx_install_package: true
     templates:
       - publish-to-pypi
       - publish-otc-docs-hc-pti


### PR DESCRIPTION
When we try to build json output we actually usually rely on the theme
installed through requirements. Here we end up not having the theme
itself.

Depends-On: https://github.com/opentelekomcloud-infra/otc-zuul-jobs/pull/139
