### PR TITLE
Fix pre overflow

### DIFF
--- a/otcdocstheme/theme/otcdocs/static/css/otcdocstheme.css
+++ b/otcdocstheme/theme/otcdocs/static/css/otcdocstheme.css
@@ -405,6 +405,11 @@ div.docs-sidebar-toc li.toctree-l1 > a {
 /* SIDEBAR END */
 
 /* CONTENT */
+/* Fix pre blocks not to strech width */
+.row {
+  min-width: 0;
+}
+
 /* Chapters include normally invisible (P) symbol */
 a {
   color: var(--dt-color-blue-60);
@@ -632,6 +637,7 @@ pre {
   overflow: auto;
   margin: 0 0 10px;
   padding: 20px 30px;
+  max-width: 100%;
 }
 
 pre code,


### PR DESCRIPTION
when pre block has long lines it stretches parents. In order
to prevent this it is required to set min-width: 0 for the parenting
flex block.
