### PR TITLE
Set otcdocstheme.css as main css

### DIFF
--- a/otcdocstheme/theme/otcdocs/css.html
+++ b/otcdocstheme/theme/otcdocs/css.html
@@ -5,12 +5,6 @@
 <link href="{{pathto('_static/css/fontawesome-all.min.css', 1)}}" rel="stylesheet">
 <link rel="preload" href="{{pathto('_static/webfonts/fa-regular-400.woff2', 1)}}" as="font" type="font/woff2" crossorigin>
 
-<!-- Pygments CSS -->
-<link href="{{pathto('_static/pygments.css', 1)}}" rel="stylesheet">
-
-<!-- Otcdocstheme CSS -->
-<link href="{{pathto('_static/css/otcdocstheme.css', 1)}}" rel="stylesheet">
-
 <!-- Favicon -->
 <link rel="icon" href="{{pathto('_static/favicon.ico', 1)}}" type="image/x-icon"/>
 

--- a/otcdocstheme/theme/otcdocs/layout.html
+++ b/otcdocstheme/theme/otcdocs/layout.html
@@ -52,12 +52,9 @@
 
   {%- block relbar2 %}{% endblock %}
 
-
-
   {%- block footer %}
   {% include 'footer.html' %}
   {% include 'script_footer.html' %}
   {% block script_footer %}{% endblock %}
   {%- endblock %}
 </div>
-

--- a/otcdocstheme/theme/otcdocs/static/css/otcdocstheme.css
+++ b/otcdocstheme/theme/otcdocs/static/css/otcdocstheme.css
@@ -177,7 +177,7 @@ body {
 /* Sizing */
 /* force using full screen */
 .container-xxl {
-  max-width: unset;
+  max-width: unset !important;
 }
 
 /* End Sizing */
@@ -194,7 +194,7 @@ body {
 }
 
 .docs-navbar {
-  padding: 0 0 0.75rem 0;
+  padding: 0 0 0.75rem 0 !important;
   background: var(--dt-color-magenta);
   /*display: flex;*/
   /*height: 72px;
@@ -319,7 +319,7 @@ body {
 /* Breadcrumbs */
 
 @media (min-width: 576px) {
-  .ul-breadcrumbs {
+  .docs-book-wrapper .ul-breadcrumbs {
     list-style-image: none;
     list-style: none;
     margin: 0;
@@ -329,7 +329,7 @@ body {
   }
 }
 @media(max-width: 575px) {
-  .ul-breadcrumbs {
+  .docs-book-wrapper .ul-breadcrumbs {
     list-style-image: none;
     list-style: none;
     margin: 0;
@@ -547,10 +547,11 @@ a.headerlink:hover {
   color: var(--dt-color-blue-60);
 }
 
-h1 {
+.docs-content h1 {
   font-weight: 400;
 }
 
+.docs-content
 h2,
 h3,
 h4,
@@ -562,7 +563,7 @@ main h1, h2, h3, h4, h5 {
   color: var(--dt-color-grey-70);
 }
 
-h1, h2, h3 {
+.docs-content h1, h2, h3 {
   margin-bottom: 1rem;
 }
 

--- a/otcdocstheme/theme/otcdocs/theme.conf
+++ b/otcdocstheme/theme/otcdocs/theme.conf
@@ -1,6 +1,6 @@
 [theme]
 inherit = basic
-stylesheet = css/basic.css
+stylesheet = css/otcdocstheme.css
 pygments_style = native
 
 [options]


### PR DESCRIPTION
In order to avoid sphinx setting default css to default.css which
doesn't exist set it to otcdocstheme instead.
Since now bootstrap loads later and override something we used to set
adapt css selectors to ensure desired changes are applied.
