### PR TITLE
Fixed padding on breadcrumbs

### DIFF
--- a/otcdocstheme/theme/otcdocs/static/css/otcdocstheme.css
+++ b/otcdocstheme/theme/otcdocs/static/css/otcdocstheme.css
@@ -324,7 +324,7 @@ body {
     list-style: none;
     margin: 0;
     padding-bottom: 1rem;
-    padding-left: 2.5rem;
+    padding-left: 1.5rem;
     text-decoration: none;
   }
 }


### PR DESCRIPTION
This fixes the padding so that breadcrumbs are aligned correctly again after the latest commits