### PR TITLE
relocate location of bootstrap.min.css loading

### DIFF
--- a/otcdocstheme/theme/otcdocs/css.html
+++ b/otcdocstheme/theme/otcdocs/css.html
@@ -1,6 +1,3 @@
-<!-- Bootstrap CSS -->
-<link href="{{pathto('_static/css/bootstrap.min.css', 1)}}" rel="stylesheet">
-
 <!-- Fonts -->
 <link href="{{pathto('_static/css/fontawesome-all.min.css', 1)}}" rel="stylesheet">
 <link rel="preload" href="{{pathto('_static/webfonts/fa-regular-400.woff2', 1)}}" as="font" type="font/woff2" crossorigin>

--- a/otcdocstheme/theme/otcdocs/static/css/otcdocstheme.css
+++ b/otcdocstheme/theme/otcdocs/static/css/otcdocstheme.css
@@ -1,3 +1,5 @@
+@import "bootstrap.min.css";
+
 body {
   --main-body-color: #hsl(0, 0%, 9.8%);
   --bs-body-color: #hsl(0, 0%, 9.8%);


### PR DESCRIPTION
Due to the issue that there is no option to provide several css files in theme.conf, we need to load bootstrap.min.css in theme specific css file (in this case otcdocstheme.css) to load general layout statements first to enable us to overwrite statements without using !important or having to option to overwrite !important statements of bootstrap itself.