### PR TITLE
Change default logo_url to docs.otc.t-systems.com

### DIFF
--- a/otcdocstheme/theme/otcdocs/theme.conf
+++ b/otcdocstheme/theme/otcdocs/theme.conf
@@ -15,4 +15,4 @@ display_what_next = True
 display_last_updated = True
 disable_search = False
 disable_global_nav = False
-logo_url = https://docs-beta.otc.t-systems.com
+logo_url = https://docs.otc.t-systems.com


### PR DESCRIPTION
Prepare us for go-live and start building docs with proper links