### PR TITLE
Added production links in both menus 

### DIFF
--- a/otcdocstheme/theme/otcdocs/header.html
+++ b/otcdocstheme/theme/otcdocs/header.html
@@ -317,14 +317,6 @@
                   <li><a href="{{base_url}}/regions-and-endpoints/index.html" target="_blank" rel="noopener noreferrer">Endpoints</a></li>
               </ul>
             </scale-telekom-mega-menu-column>
-<!--            <scale-telekom-mega-menu-column>-->
-<!--              <a href="{{base_url}}/developer/iac.html" target="_blank" rel="noopener noreferrer" slot="heading">Automation</a>-->
-<!--              <ul>-->
-<!--                <li><a href="https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs" target="_blank" rel="noopener noreferrer">Terraform</a></li>-->
-<!--                <li><a href="{{base_url}}/ansible-collection-cloud/" target="_blank" rel="noopener noreferrer">Ansible</a></li>-->
-<!--                <li><a href="https://open-telekom-cloud.com/en/support/cloud-topology-designer" target="_blank" rel="noopener noreferrer">Cloud Topology Designer</a></li>-->
-<!--              </ul>-->
-<!--            </scale-telekom-mega-menu-column>-->
             <scale-telekom-mega-menu-column>
               <a href="{{base_url}}/developer/index.html" target="_blank" rel="noopener noreferrer" slot="heading">Development and Automation</a>
               <ul>
@@ -337,10 +329,10 @@
             </scale-telekom-mega-menu-column>
             {% if not otcdocs_search_environment == 'hc_swiss' %}
             <scale-telekom-mega-menu-column>
-              <a href="{{base_url}}/architecture-center/index.html" target="_blank" rel="noopener noreferrer" slot="heading">Architecture Center</a>
+              <a href="https://arch.otc-service.com/" target="_blank" rel="noopener noreferrer" slot="heading">Architecture Center</a>
               <ul>
-                <li><a href="{{base_url}}/architecture-center/blueprints/index.html" target="_blank" rel="noopener noreferrer">Blueprints</a></li>
-                <!-- <li><a href="{{base_url}}/architecture-center/caf/index.html" target="_blank" rel="noopener noreferrer">Cloud Adoption Framework</a></li> -->
+                <li><a href="https://arch.otc-service.com/docs/best-practices/" target="_blank" rel="noopener noreferrer">Best Practices</a></li>
+                <li><a href="https://arch.otc-service.com/docs/blueprints/" target="_blank" rel="noopener noreferrer">Blueprints</a></li>
               </ul>
             </scale-telekom-mega-menu-column>
             {% endif %}
@@ -491,9 +483,12 @@
                 <!-- Remove Architecture Center from Swiss Environment -->
                 {% if not otcdocs_search_environment == 'hc_swiss' %}
                 <scale-telekom-mobile-menu-item slot="children">
-                  <a href="{{base_url}}/architecture-center/">Architecture Center</a>
+                  <a href="https://arch.otc-service.com/">Architecture Center</a>
                   <scale-telekom-mobile-menu-item slot="children">
-                    <a href="{{base_url}}/architecture-center/blueprints/">Blueprints</a>
+                    <a href="https://arch.otc-service.com/docs/best-practices">Best Practices</a>
+                  </scale-telekom-mobile-menu-item>
+                  <scale-telekom-mobile-menu-item slot="children">
+                    <a href="https://arch.otc-service.com/docs/blueprints/">Blueprints</a>
                   </scale-telekom-mobile-menu-item>
                 </scale-telekom-mobile-menu-item>
                 {% endif %}

--- a/otcdocstheme/theme/otcdocs/header.html
+++ b/otcdocstheme/theme/otcdocs/header.html
@@ -782,9 +782,12 @@
                 <!-- Remove Architecture Center from Swiss Environment -->
                 {% if not otcdocs_search_environment == 'hc_swiss' %}
                 <scale-telekom-mobile-menu-item slot="children">
-                  <a href="{{base_url}}/architecture-center/">Architecture Center</a>
+                  <a href="https://arch.otc-service.com/">Architecture Center</a>
                   <scale-telekom-mobile-menu-item slot="children">
-                    <a href="{{base_url}}/architecture-center/blueprints/">Blueprints</a>
+                    <a href="https://arch.otc-service.com/docs/best-practices">Best Practices</a>
+                  </scale-telekom-mobile-menu-item>
+                  <scale-telekom-mobile-menu-item slot="children">
+                    <a href="https://arch.otc-service.com/docs/blueprints/">Blueprints</a>
                   </scale-telekom-mobile-menu-item>
                 </scale-telekom-mobile-menu-item>
                 {% endif %}


### PR DESCRIPTION
**Cannot be merged in production until AC goes live**

references like these `{% if service_type in ['blueprints', 'ac'] %}` were **not** removed
